### PR TITLE
Fix lower / upper case inconsistency

### DIFF
--- a/inst/app/ui/observation.js
+++ b/inst/app/ui/observation.js
@@ -21,7 +21,7 @@
  */
 
 define([
-  "app/Chart",
+  "app/chart",
   "app/utils",
   "i18next"
 ], function(Chart, utils, i18next) {

--- a/inst/app/ui/source.js
+++ b/inst/app/ui/source.js
@@ -21,9 +21,9 @@
  */
 
 define([
-  "app/Observation",
-  "app/SourcePath",
-  "app/Chart",
+  "app/observation",
+  "app/sourcepath",
+  "app/chart",
   "app/utils",
   "app/summary",
   "i18next"


### PR DESCRIPTION
Linux systems are case-sensitive so building / running this app on linux based systems (tested on linux mint & debian based docker images) leads to inconsistency in JS files requested / served by the server.  
This PR corrects this by ensuring all "define" statements are lower case.  